### PR TITLE
Added .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.unlighthouse
+node_modules


### PR DESCRIPTION
This adds a dockerignore for unlighthouse.
I had problems starting the container since it copied the contents from the current dir where I also had a .unlighthouse folder to the container and set the permissions as root then.